### PR TITLE
Remove bundler.

### DIFF
--- a/salesforce_id.gemspec
+++ b/salesforce_id.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ["ext/salesforce_id/extconf.rb"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rake-compiler"
   spec.add_development_dependency "rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,6 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'bundler'
-Bundler.setup(:default, :test, ENV['RAILS_ENV'])
-
 require 'pathname'
 require 'salesforce_id'
 require 'pry-byebug'


### PR DESCRIPTION
Hey @Fire-Dragon-DoL, 

Not everybody uses `bundler` 1.10 in their development environments. Some people prefer https://rubygems.org/gems/dep

I suggest that we remove it from the gemspec.
